### PR TITLE
Added 'encryption' config key and disabled by default 

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -158,8 +158,8 @@ class Account extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
 
     /**

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -70,8 +70,8 @@ class Bill extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']           = Crypt::encrypt($value);
-        $this->attributes['name_encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');        
     }
 
     /**

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -62,8 +62,8 @@ class Budget extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
 
     /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -43,8 +43,8 @@ class Category extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
     /**
      * @param $value

--- a/app/Models/PiggyBank.php
+++ b/app/Models/PiggyBank.php
@@ -89,8 +89,8 @@ class PiggyBank extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
     /**
      * @param $value

--- a/app/Models/Reminder.php
+++ b/app/Models/Reminder.php
@@ -88,9 +88,9 @@ class Reminder extends Model
      * @param $value
      */
     public function setMetadataAttribute($value)
-    {
-        $this->attributes['encrypted'] = true;
-        $this->attributes['metadata'] = Crypt::encrypt(json_encode($value));
+    {        
+        $this->attributes['encrypted']  = \Config::get('database.encryption');        
+        $this->attributes['metadata']   = \Config::get('database.encryption') ? Crypt::encrypt(json_encode($value)) : json_encode($value);
     }
 
     /**

--- a/app/Models/TransactionJournal.php
+++ b/app/Models/TransactionJournal.php
@@ -184,8 +184,8 @@ class TransactionJournal extends Model
      */
     public function setDescriptionAttribute($value)
     {
-        $this->attributes['description'] = \Crypt::encrypt($value);
-        $this->attributes['encrypted']   = true;
+        $this->attributes['description']    = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted']      = \Config::get('database.encryption');        
     }
 
     /**

--- a/app/Repositories/Journal/JournalRepository.php
+++ b/app/Repositories/Journal/JournalRepository.php
@@ -133,6 +133,7 @@ class JournalRepository implements JournalRepositoryInterface
                 'description'             => $data['description'],
                 'completed'               => 0,
                 'date'                    => $data['date'],
+                'encrypted'               => \Config::get('database.encryption'),
             ]
         );
         $journal->save();

--- a/config/database.php
+++ b/config/database.php
@@ -122,4 +122,15 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption
+    |--------------------------------------------------------------------------
+    |
+    | Configures whether to encrypt values within the database or not.
+    |
+    */
+
+    'encryption' => false,
+
 ];


### PR DESCRIPTION
Encryption causes a lots of trouble when ordering list items and detecting duplicates:

- Whenever you create a new transaction and assign it to an existing category the category become duplicated (by `firstOrCreate()`)
- Account and category lists cannot be ordered by name (or at least by the original name) because they ordered by encrypted values.

*Personally I prefer unencrypted values, because sometimes I would like to run direct SQL queries on the database.*