### PR TITLE
Added 'encryption' config key and disabled by default 

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -7,6 +7,7 @@ use Input;
 use Preferences;
 use Session;
 use Redirect;
+use Config;
 /**
  * Class HomeController
  *
@@ -41,7 +42,8 @@ class HomeController extends Controller
     public function index(AccountRepositoryInterface $repository)
     {
 
-        $count         = $repository->countAssetAccounts();
+        $types        = Config::get('firefly.accountTypesByIdentifier.asset');
+        $count         = $repository->countAccounts($types);
         $title         = 'Firefly';
         $subTitle      = 'What\'s playing?';
         $mainTitleIcon = 'fa-fire';

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -158,8 +158,8 @@ class Account extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
 
     /**

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -70,8 +70,8 @@ class Bill extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']           = Crypt::encrypt($value);
-        $this->attributes['name_encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');        
     }
 
     /**

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -62,8 +62,8 @@ class Budget extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
 
     /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -43,8 +43,8 @@ class Category extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
     /**
      * @param $value

--- a/app/Models/PiggyBank.php
+++ b/app/Models/PiggyBank.php
@@ -89,8 +89,8 @@ class PiggyBank extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = \Config::get('database.encryption');
     }
     /**
      * @param $value

--- a/app/Models/Reminder.php
+++ b/app/Models/Reminder.php
@@ -88,9 +88,9 @@ class Reminder extends Model
      * @param $value
      */
     public function setMetadataAttribute($value)
-    {
-        $this->attributes['encrypted'] = true;
-        $this->attributes['metadata'] = Crypt::encrypt(json_encode($value));
+    {        
+        $this->attributes['encrypted']  = \Config::get('database.encryption');        
+        $this->attributes['metadata']   = \Config::get('database.encryption') ? Crypt::encrypt(json_encode($value)) : json_encode($value);
     }
 
     /**

--- a/app/Models/TransactionJournal.php
+++ b/app/Models/TransactionJournal.php
@@ -184,8 +184,8 @@ class TransactionJournal extends Model
      */
     public function setDescriptionAttribute($value)
     {
-        $this->attributes['description'] = \Crypt::encrypt($value);
-        $this->attributes['encrypted']   = true;
+        $this->attributes['description']    = \Config::get('database.encryption') ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted']      = \Config::get('database.encryption');        
     }
 
     /**

--- a/app/Repositories/Account/AccountRepository.php
+++ b/app/Repositories/Account/AccountRepository.php
@@ -14,6 +14,7 @@ use FireflyIII\Models\Preference;
 use FireflyIII\Models\Transaction;
 use FireflyIII\Models\TransactionJournal;
 use FireflyIII\Models\TransactionType;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Log;
@@ -29,11 +30,13 @@ class AccountRepository implements AccountRepositoryInterface
 {
 
     /**
+     * @param array $types
+     *
      * @return int
      */
-    public function countAssetAccounts()
+    public function countAccounts(array $types)
     {
-        return Auth::user()->accounts()->accountTypeIn(['Asset account', 'Default account'])->count();
+        return Auth::user()->accounts()->accountTypeIn($types)->count();
     }
 
     /**
@@ -46,6 +49,24 @@ class AccountRepository implements AccountRepositoryInterface
         $account->delete();
 
         return true;
+    }
+
+    /**
+     * @param array $types
+     * @param int   $page
+     *
+     * @return Collection
+     */
+    public function getAccounts(array $types, $page)
+    {
+        $size   = 50;
+        $offset = ($page - 1) * $size;
+
+        return Auth::user()->accounts()->with(
+            ['accountmeta' => function (HasMany $query) {
+                $query->where('name', 'accountRole');
+            }]
+        )->accountTypeIn($types)->take($size)->offset($offset)->orderBy('accounts.name', 'ASC')->get(['accounts.*']);
     }
 
     /**
@@ -131,6 +152,23 @@ class AccountRepository implements AccountRepositoryInterface
         return $paginator;
 
 
+    }
+
+    /**
+     * @param Account $account
+     *
+     * @return Carbon|null
+     */
+    public function getLastActivity(Account $account)
+    {
+        $lastTransaction = $account->transactions()->leftJoin(
+            'transaction_journals', 'transactions.transaction_journal_id', '=', 'transaction_journals.id'
+        )->orderBy('transaction_journals.date', 'DESC')->first(['transactions.*', 'transaction_journals.date']);
+        if ($lastTransaction) {
+            return $lastTransaction->transactionjournal->date;
+        }
+
+        return null;
     }
 
     /**

--- a/app/Repositories/Account/AccountRepositoryInterface.php
+++ b/app/Repositories/Account/AccountRepositoryInterface.php
@@ -17,6 +17,13 @@ use Illuminate\Support\Collection;
 interface AccountRepositoryInterface
 {
     /**
+     * @param array $types
+     *
+     * @return int
+     */
+    public function countAccounts(array $types);
+
+    /**
      * @param Account $account
      *
      * @return boolean
@@ -24,9 +31,20 @@ interface AccountRepositoryInterface
     public function destroy(Account $account);
 
     /**
-     * @return int
+     * @param array $types
+     * @param int   $page
+     *
+     * @return mixed
      */
-    public function countAssetAccounts();
+    public function getAccounts(array $types, $page);
+
+    /**
+     * @param TransactionJournal $journal
+     * @param Account            $account
+     *
+     * @return Transaction
+     */
+    public function getFirstTransaction(TransactionJournal $journal, Account $account);
 
     /**
      * @param Preference $preference
@@ -55,6 +73,27 @@ interface AccountRepositoryInterface
     /**
      * @param Account $account
      *
+     * @return Carbon|null
+     */
+    public function getLastActivity(Account $account);
+
+    /**
+     * Get savings accounts and the balance difference in the period.
+     *
+     * @return Collection
+     */
+    public function getSavingsAccounts();
+
+    /**
+     * @param Account $account
+     *
+     * @return float
+     */
+    public function leftOnAccount(Account $account);
+
+    /**
+     * @param Account $account
+     *
      * @return TransactionJournal|null
      */
     public function openingBalanceTransaction(Account $account);
@@ -73,27 +112,4 @@ interface AccountRepositoryInterface
      * @return Account
      */
     public function update(Account $account, array $data);
-
-    /**
-     * @param Account $account
-     *
-     * @return float
-     */
-    public function leftOnAccount(Account $account);
-
-    /**
-     * Get savings accounts and the balance difference in the period.
-     *
-     * @return Collection
-     */
-    public function getSavingsAccounts();
-
-
-    /**
-     * @param TransactionJournal $journal
-     * @param Account            $account
-     *
-     * @return Transaction
-     */
-    public function getFirstTransaction(TransactionJournal $journal, Account $account);
 }

--- a/app/Repositories/Journal/JournalRepository.php
+++ b/app/Repositories/Journal/JournalRepository.php
@@ -133,6 +133,7 @@ class JournalRepository implements JournalRepositoryInterface
                 'description'             => $data['description'],
                 'completed'               => 0,
                 'date'                    => $data['date'],
+                'encrypted'               => \Config::get('database.encryption'),
             ]
         );
         $journal->save();

--- a/config/database.php
+++ b/config/database.php
@@ -122,4 +122,15 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption
+    |--------------------------------------------------------------------------
+    |
+    | Configures whether to encrypt values within the database or not.
+    |
+    */
+
+    'encryption' => false,
+
 ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,7 +29,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
      */
     public static function setUpBeforeClass()
     {
-
+        parent::setUpBeforeClass();
     }
 
     /**

--- a/tests/factories/all.php
+++ b/tests/factories/all.php
@@ -48,7 +48,11 @@ FactoryMuffin::define(
 
 FactoryMuffin::define(
     'FireflyIII\Models\AccountType', [
-                                       'type'     => 'word',
+                                       'type'     => function () {
+                                           $types = ['Expense account', 'Revenue account', 'Asset account'];
+                                           $count = DB::table('account_types')->count();
+                                           return $types[$count];
+                                       },
                                        'editable' => 1,
                                    ]
 );


### PR DESCRIPTION
Encryption causes a lot of trouble when ordering lists or detecting duplicates:

- Whenever you create a new transaction and assign it to an existing category the category become duplicated (by `firstOrCreate`)
- Account and category lists cannot be ordered by name (or at least by the original name) because they ordered by encrypted values.

*Personally I prefer unencrypted values, because sometimes I would like to run direct SQL queries on the database.*