### PR TITLE
Remove another iconv()

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ DB_HOST=localhost
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
+DB_ENCRYPTION=true
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/app/Http/Controllers/GoogleChartController.php
+++ b/app/Http/Controllers/GoogleChartController.php
@@ -46,9 +46,8 @@ class GoogleChartController extends Controller
      */
     public function accountBalanceChart(Account $account, GChart $chart)
     {
-        $accountName = iconv('UTF-8', 'ASCII//TRANSLIT', $account->name);
         $chart->addColumn('Day of month', 'date');
-        $chart->addColumn('Balance for ' . $accountName, 'number');
+        $chart->addColumn('Balance for ' . $account->name, 'number');
         $chart->addCertainty(1);
 
         $start   = Session::get('start', Carbon::now()->startOfMonth());
@@ -89,8 +88,7 @@ class GoogleChartController extends Controller
         $index = 1;
         /** @var Account $account */
         foreach ($accounts as $account) {
-            $accountName = $account->name;
-            $chart->addColumn('Balance for ' . $accountName, 'number');
+            $chart->addColumn('Balance for ' . $account->name, 'number');
             $chart->addCertainty($index);
             $index++;
         }

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -158,8 +158,8 @@ class Account extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = env('DB_ENCRYPTION', true);
     }
 
     /**

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -61,8 +61,8 @@ class Bill extends Model
      */
     public function setMatchAttribute($value)
     {
-        $this->attributes['match']           = Crypt::encrypt($value);
-        $this->attributes['match_encrypted'] = true;
+        $this->attributes['match']           = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['match_encrypted'] = env('DB_ENCRYPTION', true);
     }
 
     /**
@@ -70,8 +70,8 @@ class Bill extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']           = Crypt::encrypt($value);
-        $this->attributes['name_encrypted'] = true;
+        $this->attributes['name']      = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = env('DB_ENCRYPTION', true);
     }
 
     /**

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -62,8 +62,8 @@ class Budget extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = env('DB_ENCRYPTION', true);
     }
 
     /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -43,8 +43,8 @@ class Category extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = env('DB_ENCRYPTION', true);
     }
     /**
      * @param $value

--- a/app/Models/PiggyBank.php
+++ b/app/Models/PiggyBank.php
@@ -89,8 +89,8 @@ class PiggyBank extends Model
      */
     public function setNameAttribute($value)
     {
-        $this->attributes['name']      = Crypt::encrypt($value);
-        $this->attributes['encrypted'] = true;
+        $this->attributes['name']      = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted'] = env('DB_ENCRYPTION', true);
     }
     /**
      * @param $value

--- a/app/Models/Reminder.php
+++ b/app/Models/Reminder.php
@@ -88,9 +88,9 @@ class Reminder extends Model
      * @param $value
      */
     public function setMetadataAttribute($value)
-    {
-        $this->attributes['encrypted'] = true;
-        $this->attributes['metadata'] = Crypt::encrypt(json_encode($value));
+    {        
+        $this->attributes['encrypted']  = env('DB_ENCRYPTION', true);        
+        $this->attributes['metadata']   = env('DB_ENCRYPTION', true) ? Crypt::encrypt(json_encode($value)) : json_encode($value);
     }
 
     /**

--- a/app/Models/TransactionJournal.php
+++ b/app/Models/TransactionJournal.php
@@ -184,8 +184,8 @@ class TransactionJournal extends Model
      */
     public function setDescriptionAttribute($value)
     {
-        $this->attributes['description'] = \Crypt::encrypt($value);
-        $this->attributes['encrypted']   = true;
+        $this->attributes['description']    = env('DB_ENCRYPTION', true) ? Crypt::encrypt($value) : $value;
+        $this->attributes['encrypted']      = env('DB_ENCRYPTION', true);        
     }
 
     /**

--- a/app/Repositories/Account/AccountRepository.php
+++ b/app/Repositories/Account/AccountRepository.php
@@ -403,7 +403,7 @@ class AccountRepository implements AccountRepositoryInterface
                 'description'             => 'Initial balance for "' . $account->name . '"',
                 'completed'               => true,
                 'date'                    => $data['openingBalanceDate'],
-                'encrypted'               => true
+                'encrypted'               => env('DB_ENCRYPTION', true)
             ]
         );
         if (!$journal->isValid()) {

--- a/app/Repositories/Journal/JournalRepository.php
+++ b/app/Repositories/Journal/JournalRepository.php
@@ -133,6 +133,7 @@ class JournalRepository implements JournalRepositoryInterface
                 'description'             => $data['description'],
                 'completed'               => 0,
                 'date'                    => $data['date'],
+                'encrypted'               => env('DB_ENCRYPTION', true),
             ]
         );
         $journal->save();


### PR DESCRIPTION
Removed another iconv() call. The encoding issue has been fixed by grumpydictator/gchart 1.0.9.