### PR TITLE
Remove another iconv()

### DIFF
--- a/app/Http/Controllers/GoogleChartController.php
+++ b/app/Http/Controllers/GoogleChartController.php
@@ -46,9 +46,8 @@ class GoogleChartController extends Controller
      */
     public function accountBalanceChart(Account $account, GChart $chart)
     {
-        $accountName = iconv('UTF-8', 'ASCII//TRANSLIT', $account->name);
         $chart->addColumn('Day of month', 'date');
-        $chart->addColumn('Balance for ' . $accountName, 'number');
+        $chart->addColumn('Balance for ' . $account->name, 'number');
         $chart->addCertainty(1);
 
         $start   = Session::get('start', Carbon::now()->startOfMonth());
@@ -89,8 +88,7 @@ class GoogleChartController extends Controller
         $index = 1;
         /** @var Account $account */
         foreach ($accounts as $account) {
-            $accountName = $account->name;
-            $chart->addColumn('Balance for ' . $accountName, 'number');
+            $chart->addColumn('Balance for ' . $account->name, 'number');
             $chart->addCertainty($index);
             $index++;
         }


### PR DESCRIPTION
Removed another iconv() call. The encoding issue has been fixed by grumpydictator/gchart 1.0.9.