### PR TITLE
use relative path in login screen

### DIFF
--- a/resources/twig/auth/login.twig
+++ b/resources/twig/auth/login.twig
@@ -18,7 +18,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">Sign in to start your session</p>
 
-        <form action="/auth/login" method="post">
+        <form action="auth/login" method="post">
             <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 
             <div class="form-group has-feedback">
@@ -45,7 +45,7 @@
         {% if Config.get('auth.allow_register') %}
             <a href="{{ route('register') }}" class="text-center">Register a new account</a><br>
         {% endif %}
-        <a href="/password/email">I forgot my password</a>
+        <a href="password/email">I forgot my password</a>
     </div>
     <!-- /.login-box-body -->
 {% endblock %}

--- a/resources/twig/auth/password.twig
+++ b/resources/twig/auth/password.twig
@@ -23,7 +23,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">Reset your password</p>
 
-        <form role="form" method="POST" action="/password/email">
+        <form role="form" method="POST" action="password/email">
             <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 
             <div class="form-group has-feedback">
@@ -40,8 +40,8 @@
 
         </form>
 
-        <a href="/auth/login">I want to login</a><br>
-        <a href="/password/email">I forgot my password</a>
+        <a href="auth/login">I want to login</a><br>
+        <a href="password/email">I forgot my password</a>
 
     </div><!-- /.login-box-body -->
 

--- a/resources/twig/auth/register.twig
+++ b/resources/twig/auth/register.twig
@@ -18,7 +18,7 @@
     <div class="register-box-body">
         <p class="login-box-msg">Register a new account</p>
 
-        <form role="form" id="register" method="POST" action="/auth/register">
+        <form role="form" id="register" method="POST" action="auth/register">
             <input type="hidden" name="_token" value="{{ csrf_token() }}">
 
             <div class="form-group has-feedback">
@@ -38,8 +38,8 @@
             </div>
         </form>
 
-        <a href="/auth/login">I want to login</a><br>
-        <a href="/password/email">I forgot my password</a>
+        <a href="auth/login">I want to login</a><br>
+        <a href="password/email">I forgot my password</a>
     </div><!-- /.form-box -->
 
 {% endblock %}


### PR DESCRIPTION
I was installing firefly-III om my box. Configured my webserver to have a firefly in a sub directory. This caused some troubles when trying to log in.
The issues were caused by a leading slash in some of the links. If the slash is removed, the path will be relative and it works form the subdirectory.