### PR TITLE
use relative path in login screen improved

### DIFF
--- a/resources/twig/auth/login.twig
+++ b/resources/twig/auth/login.twig
@@ -18,7 +18,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">Sign in to start your session</p>
 
-        <form action="/auth/login" method="post">
+        <form action="auth/login" method="post">
             <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 
             <div class="form-group has-feedback">
@@ -45,7 +45,7 @@
         {% if Config.get('auth.allow_register') %}
             <a href="{{ route('register') }}" class="text-center">Register a new account</a><br>
         {% endif %}
-        <a href="/password/email">I forgot my password</a>
+        <a href="password/email">I forgot my password</a>
     </div>
     <!-- /.login-box-body -->
 {% endblock %}

--- a/resources/twig/auth/login.twig
+++ b/resources/twig/auth/login.twig
@@ -18,7 +18,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">Sign in to start your session</p>
 
-        <form action="auth/login" method="post">
+        <form action="{{ URL.to('/auth/login' }}" method="post">
             <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 
             <div class="form-group has-feedback">
@@ -45,7 +45,7 @@
         {% if Config.get('auth.allow_register') %}
             <a href="{{ route('register') }}" class="text-center">Register a new account</a><br>
         {% endif %}
-        <a href="password/email">I forgot my password</a>
+        <a href="{{ URL.to('/password/email' }}">I forgot my password</a>
     </div>
     <!-- /.login-box-body -->
 {% endblock %}

--- a/resources/twig/auth/password.twig
+++ b/resources/twig/auth/password.twig
@@ -23,7 +23,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">Reset your password</p>
 
-        <form role="form" method="POST" action="password/email">
+        <form role="form" method="POST" action="{{ URL.to('/password/email' }}">
             <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 
             <div class="form-group has-feedback">
@@ -40,8 +40,8 @@
 
         </form>
 
-        <a href="auth/login">I want to login</a><br>
-        <a href="password/email">I forgot my password</a>
+        <a href="{{ URL.to('/auth/login' }}">I want to login</a><br>
+        <a href="{{ URL.to('/password/email' }}">I forgot my password</a>
 
     </div><!-- /.login-box-body -->
 

--- a/resources/twig/auth/password.twig
+++ b/resources/twig/auth/password.twig
@@ -23,7 +23,7 @@
     <div class="login-box-body">
         <p class="login-box-msg">Reset your password</p>
 
-        <form role="form" method="POST" action="/password/email">
+        <form role="form" method="POST" action="password/email">
             <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 
             <div class="form-group has-feedback">
@@ -40,8 +40,8 @@
 
         </form>
 
-        <a href="/auth/login">I want to login</a><br>
-        <a href="/password/email">I forgot my password</a>
+        <a href="auth/login">I want to login</a><br>
+        <a href="password/email">I forgot my password</a>
 
     </div><!-- /.login-box-body -->
 

--- a/resources/twig/auth/register.twig
+++ b/resources/twig/auth/register.twig
@@ -18,7 +18,7 @@
     <div class="register-box-body">
         <p class="login-box-msg">Register a new account</p>
 
-        <form role="form" id="register" method="POST" action="auth/register">
+        <form role="form" id="register" method="POST" action="{{ URL.to('/auth/register' }}">
             <input type="hidden" name="_token" value="{{ csrf_token() }}">
 
             <div class="form-group has-feedback">
@@ -38,8 +38,8 @@
             </div>
         </form>
 
-        <a href="auth/login">I want to login</a><br>
-        <a href="password/email">I forgot my password</a>
+        <a href="{{ URL.to('/auth/login' }}">I want to login</a><br>
+        <a href="{{ URL.to('/password/email' }}">I forgot my password</a>
     </div><!-- /.form-box -->
 
 {% endblock %}

--- a/resources/twig/auth/register.twig
+++ b/resources/twig/auth/register.twig
@@ -18,7 +18,7 @@
     <div class="register-box-body">
         <p class="login-box-msg">Register a new account</p>
 
-        <form role="form" id="register" method="POST" action="/auth/register">
+        <form role="form" id="register" method="POST" action="auth/register">
             <input type="hidden" name="_token" value="{{ csrf_token() }}">
 
             <div class="form-group has-feedback">
@@ -38,8 +38,8 @@
             </div>
         </form>
 
-        <a href="/auth/login">I want to login</a><br>
-        <a href="/password/email">I forgot my password</a>
+        <a href="auth/login">I want to login</a><br>
+        <a href="password/email">I forgot my password</a>
     </div><!-- /.form-box -->
 
 {% endblock %}


### PR DESCRIPTION
Improvement of previous pull request #85. This update uses the URL.to method for renedering the URL's on the login screen.