### PR TITLE
String is a reserved class name in php 7.

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -94,7 +94,7 @@ return [
             'TwigBridge\Extension\Laravel\Dump',
             'TwigBridge\Extension\Laravel\Input',
             'TwigBridge\Extension\Laravel\Session',
-            'TwigBridge\Extension\Laravel\String',
+            'TwigBridge\Extension\Laravel\Str',
             'TwigBridge\Extension\Laravel\Translator',
             'TwigBridge\Extension\Laravel\Url',
 


### PR DESCRIPTION
The upstream project has changed the class to Str.
