### PR TITLE
Quicklink fiscal year report feature. As per github issue #131.

### DIFF
--- a/app/Support/Binder/Date.php
+++ b/app/Support/Binder/Date.php
@@ -11,6 +11,7 @@ namespace FireflyIII\Support\Binder;
 
 use Auth;
 use Carbon\Carbon;
+use FireflyIII\Helpers\FiscalHelper;
 use Exception;
 use Log;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -32,6 +33,8 @@ class Date implements BinderInterface
      */
     public static function routeBinder($value, $route)
     {
+        $fiscalHelper = new FiscalHelper;
+
         switch ($value) {
             default:
                 try {
@@ -50,6 +53,10 @@ class Date implements BinderInterface
                 return Carbon::now()->startOfYear();
             case 'currentYearEnd':
                 return Carbon::now()->endOfYear();
+            case 'currentFiscalYearStart':
+                return $fiscalHelper->startOfFiscalYear(Carbon::now());
+            case 'currentFiscalYearEnd':
+                return $fiscalHelper->endOfFiscalYear(Carbon::now());
 
         }
     }

--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -488,6 +488,7 @@ return [
     'quick_link_default_report'              => 'Default financial report',
     'report_this_month_quick'                => 'Current month, all accounts',
     'report_this_year_quick'                 => 'Current year, all accounts',
+    'report_this_fiscal_year_quick'          => 'Current fiscal year, all accounts',
     'report_all_time_quick'                  => 'All-time, all accounts',
     'reports_can_bookmark'                   => 'Remember that reports can be bookmarked.',
     'incomeVsExpenses'                       => 'Income vs. expenses',

--- a/resources/views/reports/index.twig
+++ b/resources/views/reports/index.twig
@@ -111,6 +111,14 @@
                         <li>
                             <a href="{{ route('reports.report',
                             ['default',
+                            'currentFiscalYearStart',
+                            'currentFiscalYearEnd',
+                            accountList
+                            ]) }}">{{ 'report_this_fiscal_year_quick'|_ }}</a>
+                        </li>
+                        <li>
+                            <a href="{{ route('reports.report',
+                            ['default',
                             start.format('Ymd'),
                             'currentMonthEnd',
                             accountList


### PR DESCRIPTION
As per the discussion on issue #131 I have added a current fiscal year quicklink report.

The reason for instantiating the helper at the beginning of the static function routeBinder
is I am hoping that the object will only be created once. But I am not very familiar with the workings of static functions so I could be wrong.