### PR TITLE
Check for triggers that match anything

### DIFF
--- a/app/Models/RuleTrigger.php
+++ b/app/Models/RuleTrigger.php
@@ -36,4 +36,12 @@ class RuleTrigger extends Model
     {
         return $this->belongsTo('FireflyIII\Models\Rule');
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * For example: amount > 0 or description starts with '' 
+     */
+    public function matchesAnything() {
+        return TriggerFactory::getTrigger($this, new TransactionJournal)->matchesAnything();
+    }
 }

--- a/app/Rules/Triggers/AmountExactly.php
+++ b/app/Rules/Triggers/AmountExactly.php
@@ -62,4 +62,11 @@ class AmountExactly implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * For example: amount > 0 or description starts with ''
+     * @return bool
+     */
+    public function matchesAnything() { return false; }
 }

--- a/app/Rules/Triggers/AmountLess.php
+++ b/app/Rules/Triggers/AmountLess.php
@@ -62,4 +62,11 @@ class AmountLess implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * For example: amount > 0 or description starts with ''
+     * @return bool
+     */
+    public function matchesAnything() { return false; }    
 }

--- a/app/Rules/Triggers/AmountMore.php
+++ b/app/Rules/Triggers/AmountMore.php
@@ -62,4 +62,13 @@ class AmountMore implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is zero
+     * @return bool
+     */
+    public function matchesAnything() { 
+        return bccomp('0', $this->trigger->trigger_value) === 0; 
+    }
 }

--- a/app/Rules/Triggers/DescriptionContains.php
+++ b/app/Rules/Triggers/DescriptionContains.php
@@ -63,4 +63,13 @@ class DescriptionContains implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }    
 }

--- a/app/Rules/Triggers/DescriptionEnds.php
+++ b/app/Rules/Triggers/DescriptionEnds.php
@@ -72,4 +72,14 @@ class DescriptionEnds implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+    
 }

--- a/app/Rules/Triggers/DescriptionIs.php
+++ b/app/Rules/Triggers/DescriptionIs.php
@@ -58,4 +58,11 @@ class DescriptionIs implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * @return bool
+     */
+    public function matchesAnything() { return false; }
+    
 }

--- a/app/Rules/Triggers/DescriptionStarts.php
+++ b/app/Rules/Triggers/DescriptionStarts.php
@@ -60,4 +60,14 @@ class DescriptionStarts implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+    
 }

--- a/app/Rules/Triggers/FromAccountContains.php
+++ b/app/Rules/Triggers/FromAccountContains.php
@@ -62,4 +62,14 @@ class FromAccountContains implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+    
 }

--- a/app/Rules/Triggers/FromAccountEnds.php
+++ b/app/Rules/Triggers/FromAccountEnds.php
@@ -72,4 +72,15 @@ class FromAccountEnds implements TriggerInterface
         return false;
 
     }
+    
+
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+        
 }

--- a/app/Rules/Triggers/FromAccountIs.php
+++ b/app/Rules/Triggers/FromAccountIs.php
@@ -58,4 +58,11 @@ class FromAccountIs implements TriggerInterface
         return false;
 
     }
+
+    /**
+     * Checks whether this trigger will match all transactions
+     * @return bool
+     */
+    public function matchesAnything() { return false; }
+        
 }

--- a/app/Rules/Triggers/FromAccountStarts.php
+++ b/app/Rules/Triggers/FromAccountStarts.php
@@ -60,4 +60,15 @@ class FromAccountStarts implements TriggerInterface
         return false;
 
     }
+    
+
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+        
 }

--- a/app/Rules/Triggers/ToAccountContains.php
+++ b/app/Rules/Triggers/ToAccountContains.php
@@ -62,4 +62,15 @@ class ToAccountContains implements TriggerInterface
         return false;
 
     }
+    
+
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+        
 }

--- a/app/Rules/Triggers/ToAccountEnds.php
+++ b/app/Rules/Triggers/ToAccountEnds.php
@@ -72,4 +72,14 @@ class ToAccountEnds implements TriggerInterface
         return false;
 
     }
+    
+
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
 }

--- a/app/Rules/Triggers/ToAccountIs.php
+++ b/app/Rules/Triggers/ToAccountIs.php
@@ -58,4 +58,11 @@ class ToAccountIs implements TriggerInterface
         return false;
 
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * @return bool
+     */
+    public function matchesAnything() { return false; }
+    
 }

--- a/app/Rules/Triggers/ToAccountStarts.php
+++ b/app/Rules/Triggers/ToAccountStarts.php
@@ -60,4 +60,15 @@ class ToAccountStarts implements TriggerInterface
         return false;
 
     }
+    
+
+    /**
+     * Checks whether this trigger will match all transactions
+     * This happens when the trigger_value is empty
+     * @return bool
+     */
+    public function matchesAnything() {
+        return $this->trigger->trigger_value === "";
+    }
+        
 }

--- a/app/Rules/Triggers/TransactionType.php
+++ b/app/Rules/Triggers/TransactionType.php
@@ -57,4 +57,11 @@ class TransactionType implements TriggerInterface
 
         return false;
     }
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * @return bool
+     */
+    public function matchesAnything() { return false; }
+    
 }

--- a/app/Rules/Triggers/TriggerInterface.php
+++ b/app/Rules/Triggers/TriggerInterface.php
@@ -32,4 +32,11 @@ interface TriggerInterface
      * @return bool
      */
     public function triggered();
+    
+    /**
+     * Checks whether this trigger will match all transactions
+     * For example: amount > 0 or description starts with ''
+     * @return bool
+     */
+    public function matchesAnything();
 }

--- a/app/Rules/Triggers/UserAction.php
+++ b/app/Rules/Triggers/UserAction.php
@@ -53,4 +53,10 @@ class UserAction implements TriggerInterface
         return true;
     }
 
+    /**
+     * Checks whether this trigger will match all transactions
+     * @return bool
+     */
+    public function matchesAnything() { return true; }
+    
 }


### PR DESCRIPTION
For proper implementation of a feature to run rules on existing transactions, a check was needed to see if a trigger would match any transaction. In that case, the user should be warned. To perform this check, I've extended the existing trigger objects to do type-specific checks.