### PR TITLE
Fix use of absolute URLs for linecharts for the report pages.

### DIFF
--- a/public/js/reports/default/month.js
+++ b/public/js/reports/default/month.js
@@ -17,7 +17,7 @@ function drawChart() {
 
     // month view:
     // draw account chart
-    lineChart('/chart/account/report/' + reportType + '/' + startDate + '/' + endDate + '/' + accountIds, 'account-balances-chart');
+    lineChart('chart/account/report/' + reportType + '/' + startDate + '/' + endDate + '/' + accountIds, 'account-balances-chart');
 }
 
 

--- a/public/js/reports/default/reports.js
+++ b/public/js/reports/default/reports.js
@@ -116,7 +116,7 @@ function drawChart() {
     }
 
     if (typeof lineChart !== 'undefined' && typeof accountIds !== 'undefined') {
-        lineChart('/chart/account/report/' + reportType + '/' + startDate + '/' + endDate + '/' + accountIds, 'account-balances-chart');
+        lineChart('chart/account/report/' + reportType + '/' + startDate + '/' + endDate + '/' + accountIds, 'account-balances-chart');
     }
 }
 


### PR DESCRIPTION
The line charts on report pages weren't loading for me, turns out the graphs were trying to load the data from an absolute instead of a relative URL.