### PR TITLE
add migration that correctly sets nullable for description fields on rules and rule_groups

### DIFF
--- a/database/migrations/2016_09_12_121359_fix_nullables.php
+++ b/database/migrations/2016_09_12_121359_fix_nullables.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixNullables extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(
+            'rule_groups', function (Blueprint $table)
+        {
+            $table->text('description')->nullable()->change();
+        }
+        );
+
+        Schema::table(
+            'rules', function (Blueprint $table)
+        {
+            $table->text('description')->nullable()->change();
+        }
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}


### PR DESCRIPTION
This should fix #310 by adding a migration that updates the nullable values. Users would have to perform an `php artisan migrate` to apply the change.