### PR TITLE
PostgreSQL compatibility

### DIFF
--- a/app/Import/ImportStorage.php
+++ b/app/Import/ImportStorage.php
@@ -185,7 +185,7 @@ class ImportStorage
                    ->where('rules.active', 1)
                    ->orderBy('rule_groups.order', 'ASC')
                    ->orderBy('rules.order', 'ASC')
-                   ->get(['rules.*']);
+                   ->get(['rules.*', 'rule_groups.order']);
         Log::debug(sprintf('Found %d user rules.', $set->count()));
 
         return $set;

--- a/app/Repositories/Budget/BudgetRepository.php
+++ b/app/Repositories/Budget/BudgetRepository.php
@@ -23,6 +23,7 @@ use FireflyIII\Models\TransactionJournal;
 use FireflyIII\Models\TransactionType;
 use FireflyIII\User;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 
@@ -368,9 +369,22 @@ class BudgetRepository implements BudgetRepositoryInterface
         }
         if ($accounts->count() > 0) {
             $accountIds = $accounts->pluck('id')->toArray();
-            $set        = join(', ', $accountIds);
-            $query->whereRaw('(source.account_id in (' . $set . ') XOR destination.account_id in (' . $set . '))');
-
+            $query->where(
+                // source.account_id in accountIds XOR destination.account_id in accountIds
+                function (Builder $sourceXorDestinationQuery) use ($accountIds) {
+                    $sourceXorDestinationQuery->where(
+                        function (Builder $inSourceButNotDestinationQuery) use ($accountIds) {
+                            $inSourceButNotDestinationQuery->whereIn('source.account_id', $accountIds)
+                                                           ->whereNotIn('destination.account_id', $accountIds);
+                        }
+                    )->orWhere(
+                        function (Builder $inDestinationButNotSourceQuery) use ($accountIds) {
+                            $inDestinationButNotSourceQuery->whereIn('destination.account_id', $accountIds)
+                                                           ->whereNotIn('source.account_id', $accountIds);
+                        }
+                    );
+                }
+            );
         }
         if ($budgets->count() > 0) {
             $budgetIds = $budgets->pluck('id')->toArray();
@@ -445,9 +459,22 @@ class BudgetRepository implements BudgetRepositoryInterface
 
         if ($accounts->count() > 0) {
             $accountIds = $accounts->pluck('id')->toArray();
-
-            $set = join(', ', $accountIds);
-            $query->whereRaw('(source.account_id in (' . $set . ') XOR destination.account_id in (' . $set . '))');
+            $query->where(
+                // source.account_id in accountIds XOR destination.account_id in accountIds
+                function (Builder $sourceXorDestinationQuery) use ($accountIds) {
+                    $sourceXorDestinationQuery->where(
+                        function (Builder $inSourceButNotDestinationQuery) use ($accountIds) {
+                            $inSourceButNotDestinationQuery->whereIn('source.account_id', $accountIds)
+                                                           ->whereNotIn('destination.account_id', $accountIds);
+                        }
+                    )->orWhere(
+                        function (Builder $inDestinationButNotSourceQuery) use ($accountIds) {
+                            $inDestinationButNotSourceQuery->whereIn('destination.account_id', $accountIds)
+                                                           ->whereNotIn('source.account_id', $accountIds);
+                        }
+                    );
+                }
+            );
         }
         $ids = $query->get(['transaction_journals.id'])->pluck('id')->toArray();
         $sum = '0';


### PR DESCRIPTION
This pull request introduces PostgreSQL compatibility, and potentially compatibility for other databases as well.
More specifically, the use of XOR has been replaced with a construct native to Eloquent.

This is intended to fix #346 and might also fix #279.

@JC5 I realize there is a lot of code duplication but I was unsure of where to refactor the duplicate code to. Feel free to point me in the right direction or do it yourself.