### PR TITLE
Require PHP intl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
   ],
   "require": {
     "php": ">=7.0.0",
+    "ext-intl": "*",
     "laravel/framework": "5.3.*",
     "davejamesmiller/laravel-breadcrumbs": "^3.0",
     "watson/validating": "^3.0",


### PR DESCRIPTION
The intl extension is used for NumberFormatter at the very least. Explicitly requiring it in composer.json would make troubleshooting the install much simpler. I had to do a surprising amount of googling before finding out numfmt_create was in the intl extension.

Having done this I have a perfectly-working firefly install in a development environment though 😁 