### PR TITLE
Added dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM php:7-apache
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends libcurl4-openssl-dev \
+                                               zlib1g-dev \
+                                               libjpeg62-turbo-dev \
+                                               libpng12-dev \
+                                               libicu-dev \
+                                               libmcrypt-dev \
+                                               libedit-dev \
+                                               libtidy-dev \
+                                               libxml2-dev \
+                                               libsqlite3-dev \
+                                               libbz2-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install -j$(nproc) curl gd intl json mcrypt readline tidy zip bcmath xml mbstring pdo_sqlite pdo_mysql bz2
+
+# Enable apache mod rewrite..
+RUN a2enmod rewrite
+
+# Setup the Composer installer
+RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer && \
+  curl -o /tmp/composer-setup.sig https://composer.github.io/installer.sig && \
+  php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+  chmod +x /tmp/composer-setup.php && \
+  php /tmp/composer-setup.php && \
+  mv composer.phar /usr/local/bin/composer && \
+  rm -f /tmp/composer-setup.{php,sig}
+
+ADD . /var/www/firefly-iii
+RUN chown -R www-data:www-data /var/www/
+ADD docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
+
+USER www-data
+
+WORKDIR /var/www/firefly-iii
+
+RUN composer install --no-scripts --no-dev
+
+USER root

--- a/docker/apache-firefly.conf
+++ b/docker/apache-firefly.conf
@@ -1,0 +1,24 @@
+<VirtualHost *:80>
+
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/firefly-iii/public
+
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	<Directory /var/www/firefly-iii/public>
+		Options -Indexes +FollowSymLinks
+		AllowOverride All
+		Order allow,deny
+		allow from all
+	</Directory>
+</VirtualHost>
+
+
+


### PR DESCRIPTION
Ok, so this one is mostly based off #358. With a few difference which might actually make it easier.
First of all, this image is based of php:7-apache instead of ubuntu directly. Second of all, no configuration (.env) is stored in the image itself. To run this, use a run command that looks something like this
```docker run --name firefly-iii --link firefly-iii-db:db -v /data/firefly-iii/env:/var/www/firefly-iii/.env:ro firefly-iii```
This does assume there is a database with data already present, if not you'll have to run something like this first
```docker run --rm -it --link firefly-iii-db:db -v /data/firefly-iii/env:/var/www/firefly-iii/.env:ro firefly-iii php artisan migrate --seed --env=production```